### PR TITLE
Adding chef_node_name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ chef_run_list             | Run list of chef recipes or roles to bootstrap appli
 chef_attributes           | Attributes, in JSON form, to set for chef-client first boot. Optional, Default: `nil`
 chef_validation_key       | Chef organization validation key. Required: Format as single line with literal newlines (\n)
 chef_encrypted_secret_key | A encrypted_data_bag_secret to pass to the server. Optional, Default: `nil`
-wc_notify                 | Heat wait condition notification. Optional, Default : `{"status": "SUCCESS"'
+chef_node_name            | Chef client node name. Optional, Default : `$HOSTNAME`
+wc_notify                 | Heat wait condition notification. Optional, Default : `{"status": "SUCCESS"`
 
 # chef_attributes Helpers
 There are a few key helpers provided by chef_bootstrap.sh to string replace variables

--- a/chef_bootstrap.sh
+++ b/chef_bootstrap.sh
@@ -29,6 +29,14 @@ if [ -n "$chef_encrypted_secret_key" ]; then
   printf '%b\n' "$chef_encrypted_secret_key" >/etc/chef/encrypted_data_bag_secret
 fi
 
+if [ "$chef_node_name" ]; then
+  echo "chef_node_name parameter: $chef_node_name" >> $LOGFILE
+  node_name="$chef_node_name"
+else
+  echo "chef_node_name parameter: not passed" >> $LOGFILE
+  node_name="$HOSTNAME"
+fi
+
 # Cook a minimal client.rb for getting the chef-client registered
 echo "Creating a minimal /etc/chef/client.rb" >> $LOGFILE
 printf '%s\n' \
@@ -37,6 +45,7 @@ log_location     STDOUT
 chef_server_url  \"$chef_url\"
 validation_key         \"/etc/chef/validator.pem\"
 validation_client_name \"$chef_organization-validator\"
+node_name \"$node_name\"
 environment      \"$chef_environment\"" > /etc/chef/client.rb
 
 # Cook the first boot file


### PR DESCRIPTION
- Added chef_node_name as a parameter to allow configuring the `firstboot.json` with a specific value otherwise using the `$HOSTNAME`
- Updated README to reflect new parameter